### PR TITLE
Be more `no_std`

### DIFF
--- a/styled_text/src/lib.rs
+++ b/styled_text/src/lib.rs
@@ -16,7 +16,7 @@
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![no_std]
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Instead of having `std` in scope, require bringing it into scope explicitly.